### PR TITLE
CAN fwd fix, incrementing pointer instead of dereferenced value.

### DIFF
--- a/bldc_interface.c
+++ b/bldc_interface.c
@@ -827,7 +827,7 @@ void send_packet_no_fwd(unsigned char *data, unsigned int len) {
 
 static void fwd_can_append(uint8_t *data, int32_t *ind) {
 	if (can_fwd_vesc >= 0) {
-		data[*ind++] = COMM_FORWARD_CAN;
-		data[*ind++] = can_fwd_vesc;
+		data[(*ind)++] = COMM_FORWARD_CAN;
+		data[(*ind)++] = can_fwd_vesc;
 	}
 }


### PR DESCRIPTION
I was testing this code and noticed that the CAN bus forwarding fuctionality was not working. Debugging the code I found the buffer index increment on fwd_can_append was incrementing the pointer, not the value. Now its working as intended.
I am compiling this on arduino ide and testing it on an arduino mega.
