### PR TITLE
Avoid unnecessary promotion of float to double

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -83,7 +83,7 @@ void buffer_append_float32_auto(uint8_t* buffer, float number, int32_t *index) {
 	float sig_abs = fabsf(sig);
 	uint32_t sig_i = 0;
 
-	if (sig_abs >= 0.5) {
+	if (sig_abs >= 0.5f) {
 		sig_i = (uint32_t)((sig_abs - 0.5f) * 2.0f * 8388608.0f);
 		e += 126;
 	}
@@ -173,9 +173,9 @@ float buffer_get_float32_auto(const uint8_t *buffer, int32_t *index) {
 	uint32_t sig_i = res & 0x7FFFFF;
 	bool neg = res & (1 << 31);
 
-	float sig = 0.0;
+	float sig = 0.0f;
 	if (e != 0 || sig_i != 0) {
-		sig = (float)sig_i / (8388608.0 * 2.0) + 0.5;
+		sig = (float)sig_i / (8388608.0f * 2.0f) + 0.5f;
 		e -= 126;
 	}
 


### PR DESCRIPTION
The unnecessary promotion greatly increases code bloat on MCUs that don't natively support double precision floating point (and most don't).